### PR TITLE
Fix the video player overflow.

### DIFF
--- a/youtube/templates/watch.html
+++ b/youtube/templates/watch.html
@@ -113,7 +113,7 @@
             grid-column: 2;
         }
         #video-container, #video-container-inner, video{
-            height: 360px !important;
+            height: auto !important;
             width: 640px !important;
         }
         .side-videos{


### PR DESCRIPTION
When the video is not in the format 16/9, the height of the video is longer than excepted and hides some information like the title, description...