### PR TITLE
Add application/vnd.ms-excel as CSV mime type

### DIFF
--- a/youtube/subscriptions.py
+++ b/youtube/subscriptions.py
@@ -732,7 +732,7 @@ def import_subscriptions():
 
         except (AssertionError, IndexError, defusedxml.ElementTree.ParseError) as e:
             return '400 Bad Request: Unable to read opml xml file, or the file is not the expected format', 400
-    elif mime_type == 'text/csv':
+    elif mime_type in ('text/csv', 'application/vnd.ms-excel'):
         content = file.read().decode('utf-8')
         reader = csv.reader(content.splitlines())
         channels = []


### PR DESCRIPTION
Windows sends application/vnd.ms-excel as MIME Type instead of text/csv (*sigh*). Other projects also had this problem.

See:
* https://www.drupal.org/project/commerce_shipping_price_matrix/issues/2965997
* https://bugs.chromium.org/p/chromium/issues/detail?id=139105

Tested both with Firefox and Chrome. Working when I add the new MIME type. Note that this may allow other Excel files but this shouldn't be a problem since the file picker limits it anyway by default.