### PR TITLE
refactor get_subtitle_sources

### DIFF
--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -258,6 +258,9 @@ def get_subtitle_sources(info):
             # set as on by default since settings indicate to set it as such even if it's not manual
             sources[-1]['on'] = True
 
+    if settings.video_player == 1:  # Plyr
+        sources[-1]['on'] = True
+
     return sources
 
 


### PR DESCRIPTION
'settings.subtitles_language' is now a ',' seperated list of languages
that the user understands.

This allows to eliminate cases in which a translated caption would
be preferred over captions with the native language of the video, even
tough a multilingual user might understand them.