### PR TITLE
Add functional but preliminary channel tab support

### DIFF
--- a/youtube/templates/channel.html
+++ b/youtube/templates/channel.html
@@ -120,7 +120,7 @@
         </div>
     </div>
     <nav class="channel-tabs">
-        {% for tab_name in ('Videos', 'Playlists', 'About') %}
+        {% for tab_name in ('Videos', 'Shorts', 'Streams', 'Playlists', 'About') %}
             {% if tab_name.lower() == current_tab %}
                 <a class="tab page-button">{{ tab_name }}</a>
             {% else %}
@@ -159,7 +159,7 @@
     {% else %}
         <div class="content {{ current_tab + '-content'}}">
             <div id="links-metadata">
-                {% if current_tab == 'videos' %}
+                {% if current_tab in ('videos', 'shorts', 'streams') %}
                     {% set sorts = [('1', 'views'), ('2', 'oldest'), ('3', 'newest')] %}
                     <div id="number-of-results">{{ number_of_videos }} videos</div>
                 {% elif current_tab == 'playlists' %}
@@ -194,11 +194,11 @@
                 {% endfor %}
             </nav>
 
-            {% if current_tab == 'videos' and current_sort.__str__() == '2' %}
+            {% if (current_tab in ('videos', 'shorts', 'streams')) and current_sort.__str__() == '2' %}
                 <nav class="next-previous-button-row">
                     {{ common_elements.next_previous_ctoken_buttons(None, ctoken, channel_url + '/' + current_tab, parameters_dictionary) }}
                 </nav>
-            {% elif current_tab == 'videos' %}
+            {% elif current_tab in ('videos', 'shorts', 'streams') %}
                 <nav class="page-button-row">
                     {{ common_elements.page_buttons(number_of_pages, channel_url + '/' + current_tab, parameters_dictionary, include_ends=(current_sort.__str__() == '3')) }}
                 </nav>

--- a/youtube/yt_data_extract/common.py
+++ b/youtube/yt_data_extract/common.py
@@ -301,8 +301,8 @@ def extract_item_info(item, additional_info={}):
         info['id'] = multi_deep_get(item,
             ['videoId'],
             ['navigationEndpoint', 'watchEndpoint', 'videoId'],
-            ['navigationEndpoint', 'reelWatchEndpoint', 'videoId'], # shorts
-            )
+            ['navigationEndpoint', 'reelWatchEndpoint', 'videoId'] # shorts
+        )
         info['view_count'] = extract_int(item.get('viewCountText'))
 
         # dig into accessibility data to get view_count for videos marked as recommended, and to get time_published
@@ -322,15 +322,15 @@ def extract_item_info(item, additional_info={}):
         else:
             info['approx_view_count'] = extract_approx_int(multi_get(item,
                 'shortViewCountText',
-                'viewCountText') # shorts
-                )
+                'viewCountText' # shorts
+            ))
 
         # handle case where it is "No views"
         if not info['approx_view_count']:
             if ('No views' in item.get('shortViewCountText', '')
                     or 'no views' in accessibility_label.lower()
                     or 'No views' in extract_str(item.get('viewCountText', '')) # shorts
-                    ):
+            ):
                 info['view_count'] = 0
                 info['approx_view_count'] = '0'
 

--- a/youtube/yt_data_extract/common.py
+++ b/youtube/yt_data_extract/common.py
@@ -355,8 +355,7 @@ def extract_item_info(item, additional_info={}):
 
         # handle case where it is "No views"
         if not info['approx_view_count']:
-            if ('No views' in item.get('shortViewCountText', '')
-                    or 'no views' in accessibility_label.lower()):
+            if ('No views' in extract_str(item.get('viewCountText', ''))):
                 info['view_count'] = 0
                 info['approx_view_count'] = '0'
 
@@ -364,13 +363,13 @@ def extract_item_info(item, additional_info={}):
         accessibility_label = multi_deep_get(item,
             ['accessibility', 'accessibilityData', 'label'],
             default='')
-
-        duration = re.search(r'(\d+) (second|seconds|minute) - play video',
+        duration = re.search(r'(\d+) (second|seconds|minute) - play video$',
                              accessibility_label)
-        if duration.group(2) == 'minute':
-            info['duration'] = "1:00"
-        else:
-            info['duration'] = "0:" + duration.group(1).zfill(2)
+        if duration:
+            if duration.group(2) == 'minute':
+                info['duration'] = '1:00'
+            else:
+                info['duration'] = '0:' + duration.group(1).zfill(2)
 
         # if it's an item in a playlist, get its index
         if 'index' in item: # url has wrong index on playlist page

--- a/youtube/yt_data_extract/everything_else.py
+++ b/youtube/yt_data_extract/everything_else.py
@@ -73,7 +73,7 @@ def extract_channel_info(polymer_json, tab, continuation=False):
     #if 'contents' not in response and 'continuationContents' not in response:
     #    return info
 
-    if tab in ('videos', 'playlists', 'search'):
+    if tab in ('videos', 'shorts', 'streams', 'playlists', 'search'):
         items, ctoken = extract_items(response)
         additional_info = {
             'author': info['channel_name'],


### PR DESCRIPTION
Adds the foundation for displaying channel tabs (shorts and livestreams) on the channel page. the reason I call this "preliminary" is due to a severe lack of polish.

What does work:
Shorts and Streams tabs' first page
Pagination and view sort for streams
Views and duration for shorts

What does not work:
Pagination and view sort for shorts. I haven't managed to look too deep into it, but it appears that the continuation token for shorts sends the last short in the current page to get the next page, so I'm not sure if arbitrary paging is possible at the moment.
The number of pages on tabs. Due to how it's calculated, I don't know if it's possible to get the correct count for each tab. Therefore the number of pages will always be equal or larger than the true number on each tab.

Apologies if this pull request feels barebones. I hope for the code here to be used more as a general blueprint for the feature if not something that is good enough for merging.