### PR TITLE
Update token offset field

### DIFF
--- a/youtube/channel.py
+++ b/youtube/channel.py
@@ -33,6 +33,7 @@ generic_cookie = (('Cookie', 'VISITOR_INFO1_LIVE=ST1Ti53r4fU'),)
 
 # added an extra nesting under the 2nd base64 compared to v4
 # added tab support
+# changed offset field to uint id 1
 def channel_ctoken_v5(channel_id, page, sort, tab, view=1):
     new_sort = (2 if int(sort) == 1 else 1)
     offset = str(30*(int(page) - 1))
@@ -58,7 +59,7 @@ def channel_ctoken_v5(channel_id, page, sort, tab, view=1):
                                                 proto.string(2,
                                                     b"ST:"
                                                     + proto.unpadded_b64encode(
-                                                        proto.string(2, offset)
+                                                        proto.uint(1, offset)
                                                     )
                                                 )
                                             )

--- a/youtube/channel.py
+++ b/youtube/channel.py
@@ -36,7 +36,7 @@ generic_cookie = (('Cookie', 'VISITOR_INFO1_LIVE=ST1Ti53r4fU'),)
 # changed offset field to uint id 1
 def channel_ctoken_v5(channel_id, page, sort, tab, view=1):
     new_sort = (2 if int(sort) == 1 else 1)
-    offset = str(30*(int(page) - 1))
+    offset = 30*(int(page) - 1)
     if tab == 'videos':
         tab = 15
     elif tab == 'shorts':


### PR DESCRIPTION
Fix for the continuation token update. Changes the offset field to a uint with field number 1.
Additionally, I did some more research into the continuation token for shorts and this is the minimal reproducible token I could come up with (works for shorts only):
<details>
<summary>Code</summary>

```
pointless_nest = proto.string(80226972,
        proto.string(2, channel_id)
        + proto.string(3,
            proto.percent_b64encode(
                proto.string(110,
                    proto.string(3,
                        proto.string(tab,
                            proto.string(1,
                                proto.string(1,
                                    proto.unpadded_b64encode(
                                        # proto.uint(1, offset) # does nothing
                                        proto.string(3, 
                                            proto.string(100,
                                                proto.uint(2, 1)
                                            )
                                        )
                                        + proto.string(4,
                                            proto.string(1, b"1:"
                                                            + ms_unix_time)
                                        )
                                        + proto.string(5,
                                            proto.string(1, last_video)
                                        )
                                    )
                                )
                                 # targetId, just needs to be present but
                                 # doesn't need to be correct
                                + proto.string(2, "63faaff0-0000-23fe-80f0-582429d11c38")
                            )
                            # 1 - newest, 2 - popular
                            + proto.uint(3, new_sort)
                        )
                    )
                )
            )
        )
    )
```
</details>
As suspected, the offset that changes by 47 on each page doesn't actually do anything, and the last_video field is the one that progresses the returned videos. Also, there is a mysterious ms_unix_time field that should be the time in which the specific pagination request was first made (in my case, using the browser on youtube's actual website). It does not return videos with any other time.
In any case, I was unable to do anything meaningful with the token in this way, but I hope it'll be of use to upstream.