### PR TITLE
Unify homepage title

### DIFF
--- a/youtube/__init__.py
+++ b/youtube/__init__.py
@@ -18,7 +18,7 @@ yt_app.add_url_rule('/settings', 'settings_page', settings.settings_page, method
 
 @yt_app.route('/')
 def homepage():
-    return flask.render_template('home.html', title="Youtube local")
+    return flask.render_template('home.html', title="youtube-local")
 
 
 theme_names = {


### PR DESCRIPTION
The homepage HTML title is currently `Youtube local`, which isn't consistent with the rest of the program. While this could also be `YouTube Local` to make it correct with the stylisation of YouTube along with title case, it makes sense to have it unified with all other references to the program since it's always stylised that way in the rest of the repository and code.