### PR TITLE
Playability quick fix

### DIFF
--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -366,7 +366,7 @@ def extract_info(video_id, use_invidious, playlist_id=None, index=None):
         gevent.spawn(fetch_watch_page_info, video_id, playlist_id, index),
 
 
-        gevent.spawn(fetch_player_response, 'ios', video_id)
+        gevent.spawn(fetch_player_response, 'android_vr', video_id)
     )
     gevent.joinall(tasks)
     util.check_gevent_exceptions(*tasks)


### PR DESCRIPTION
The player api now expects `visitorData` information to be present either inside the json body payload or as request header `X-Goog-Visitor-Id`.

This implements a quick method to extract `visitorData` from yt homepage during player retrieval.

Also add `android_vr` client that works with `adaptiveFormats` and set watch page to use `android_vr` to get player data.
