### PR TITLE
Feature innertube captions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ urllib3>=1.24.1
 defusedxml>=0.5.0
 cachetools>=4.0.0
 stem>=1.8.0
+bbpb>=1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ urllib3>=1.24.1
 defusedxml>=0.5.0
 cachetools>=4.0.0
 stem>=1.8.0
-bbpb>=1.4.2

--- a/settings.py
+++ b/settings.py
@@ -84,6 +84,13 @@ For security reasons, enabling this is not recommended.''',
         'category': 'playback',
     }),
 
+    ('use_innertube_for_captions', {
+        'type': bool,
+        'default': False,
+        'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response.''',
+        'category': 'network',
+    }),
+
     ('default_volume', {
         'type': int,
         'default': -1,

--- a/settings.py
+++ b/settings.py
@@ -86,7 +86,7 @@ For security reasons, enabling this is not recommended.''',
 
     ('use_innertube_for_captions', {
         'type': bool,
-        'default': False,
+        'default': True,
         'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response.''',
         'category': 'network',
     }),

--- a/settings.py
+++ b/settings.py
@@ -86,7 +86,7 @@ For security reasons, enabling this is not recommended.''',
 
     ('use_innertube_for_captions', {
         'type': bool,
-        'default': True,
+        'default': False,
         'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response.''',
         'category': 'network',
     }),

--- a/youtube/innertube_caption.py
+++ b/youtube/innertube_caption.py
@@ -1,0 +1,137 @@
+import base64
+from youtube import util
+import urllib.parse
+import json
+import blackboxprotobuf
+
+def generate_caption_params(video_id: str = '', lang: str = 'en', auto_generated: bool = False):
+    typedef_2 = {
+            '1': {
+                'name': 'kind',
+                'type': 'string',
+                },
+            '2': {
+                'name': 'language_code',
+                'type': 'string',
+                },
+            '3': {
+                'name': 'empty_string',
+                'type': 'string',
+                },
+            }
+
+    typedef = {
+            '1': {
+                'name': 'videoId',
+                'type': 'string',
+                },
+            '2': {
+                'name': 'lang_param',
+                'type': 'string',
+                },
+            '3': {
+                'name': 'varint_3',
+                'type': 'int',
+                },
+            '5': {
+                'name': 'fixed_string',
+                'type': 'string',
+                },
+            '6': {
+                'name': 'varint_6',
+                'type': 'int',
+                },
+
+            '7': {
+                'name': 'varint_7',
+                'type': 'int',
+                },
+            '8': {
+                'name': 'varint_8',
+                'type': 'int',
+                },
+            }
+
+    def encode_to_protobuf(message, typedef):
+        result = blackboxprotobuf.encode_message(message, typedef)
+        return result
+
+    language_code = lang
+    if not auto_generated:
+        kind = ""
+    else:
+        kind = "asr"
+
+    two_payload = {
+            'kind': kind,
+            'language_code': language_code,
+            'empty_string': ''
+    }
+
+    two_protobuf = encode_to_protobuf(two_payload, typedef_2)
+    base64_encoded_lang = base64.b64encode(two_protobuf).decode()
+    one_payload = {
+            'videoId': video_id,
+            'lang_param': base64_encoded_lang,
+            'varint_3': 1,
+            'fixed_string': 'engagement-panel-searchable-transcript-search-panel',
+            'varint_6': 0,
+            'varint_7': 0,
+            'varint_8': 0,
+            }
+
+    one_protobuf = encode_to_protobuf(one_payload, typedef)
+
+    params = base64.b64encode(one_protobuf).decode()
+    return params
+
+def get_caption_json_resp(video_id, lang: str = 'en', auto_generated: bool = False):
+    unquoted_params = generate_caption_params(video_id, lang, auto_generated)
+    params = urllib.parse.quote(unquoted_params)
+    ytcfg = util.INNERTUBE_CLIENTS['web']
+    ua = util.desktop_user_agent
+    visitor_data = util.get_visitor_data()
+    header = { 'User-Agent': util.desktop_user_agent, 'X-Goog-Visitor-Id': visitor_data }
+    payload = {}
+    ctx = ytcfg['INNERTUBE_CONTEXT']
+    payload['context'] = ctx
+    payload['params'] = params
+    youtube_home = 'https://www.youtube.com'
+    caption_api = f"{youtube_home}/youtubei/v1/get_transcript"
+    resp = util.fetch_url(caption_api, headers=header, data=json.dumps(payload), report_text=f'Fetching captions for {video_id}')
+    if resp:
+        data = json.loads(resp)
+        return data
+    else:
+        return None
+
+def convert_milliseconds_to_hhmmss_optimized(ms):
+    if not isinstance(ms, int):
+        ms = int(ms)
+    total_seconds = ms // 1000
+    milliseconds = ms % 1000
+    hours = total_seconds // 3600
+    total_seconds %= 3600
+    minutes = total_seconds // 60
+    seconds = total_seconds % 60
+    return f"{hours:02}:{minutes:02}:{seconds:02}.{milliseconds:03}"
+
+def webvtt_from_caption_data(caption_data: dict = {}):
+    if not caption_data:
+        return None
+    vtt_body = caption_data['actions'][0]['updateEngagementPanelAction']['content']['transcriptRenderer']['content']['transcriptSearchPanelRenderer']['body']['transcriptSegmentListRenderer']['initialSegments']
+
+    vtt_content = [ 'WEBVTT\n' ]
+
+    for item in vtt_body:
+        if item.get('transcriptSegmentRenderer'):
+            vtt_item = item['transcriptSegmentRenderer']
+            ms_to_vtt_time = convert_milliseconds_to_hhmmss_optimized
+            start_time = ms_to_vtt_time(vtt_item['startMs'])
+            end_time = ms_to_vtt_time(vtt_item['endMs'])
+            running_text = vtt_item['snippet']['runs'][0]['text']
+            webvtt_time_line = str.format("""{} --> {}\n{}\n""", start_time, end_time, running_text)
+            vtt_content.append(webvtt_time_line)
+
+    vtt_txt = '\n'.join(vtt_content)
+    return vtt_txt

--- a/youtube/innertube_caption.py
+++ b/youtube/innertube_caption.py
@@ -21,8 +21,7 @@ def generate_caption_params(video_id: str = '', lang: str = 'en', auto_generated
     return base64_payload_protobuf
 
 def get_caption_json_resp(video_id, lang: str = 'en', auto_generated: bool = False):
-    unquoted_params = generate_caption_params(video_id, lang, auto_generated)
-    params = urllib.parse.quote(unquoted_params)
+    params = generate_caption_params(video_id, lang, auto_generated)
     ytcfg = util.INNERTUBE_CLIENTS['web']
     ua = util.desktop_user_agent
     visitor_data = util.get_visitor_data()

--- a/youtube/innertube_caption.py
+++ b/youtube/innertube_caption.py
@@ -86,7 +86,7 @@ def webvtt_from_caption_data(caption_data: dict = {}):
             start_time = ms_to_vtt_time(vtt_item['startMs'])
             end_time = ms_to_vtt_time(vtt_item['endMs'])
             running_text = deep_get(vtt_item, 'snippet', 'runs', 0, 'text')
-            webvtt_time_line = f'{start_time} --> {end_time}\n{running_text}'
+            webvtt_time_line = f'{start_time} --> {end_time}\n{running_text}\n'
             vtt_content.append(webvtt_time_line)
 
     vtt_txt = '\n'.join(vtt_content)

--- a/youtube/util.py
+++ b/youtube/util.py
@@ -664,12 +664,12 @@ INNERTUBE_CLIENTS = {
                 'hl': 'en',
                 'gl': 'US',
                 'clientName': 'ANDROID',
-                'clientVersion': '19.09.36',
+                'clientVersion': '20.10.38',
                 'osName': 'Android',
                 'osVersion': '12',
                 'androidSdkVersion': 31,
                 'platform': 'MOBILE',
-                'userAgent': 'com.google.android.youtube/19.09.36 (Linux; U; Android 12; US) gzip'
+                'userAgent': 'com.google.android.youtube/20.10.38 (Linux; U; Android 12; US) gzip'
             },
             # https://github.com/yt-dlp/yt-dlp/pull/575#issuecomment-887739287
             #'thirdParty': {

--- a/youtube/util.py
+++ b/youtube/util.py
@@ -666,12 +666,12 @@ INNERTUBE_CLIENTS = {
                 'hl': 'en',
                 'gl': 'US',
                 'clientName': 'ANDROID',
-                'clientVersion': '19.09.36',
+                'clientVersion': '20.10.38',
                 'osName': 'Android',
                 'osVersion': '12',
                 'androidSdkVersion': 31,
                 'platform': 'MOBILE',
-                'userAgent': 'com.google.android.youtube/19.09.36 (Linux; U; Android 12; US) gzip'
+                'userAgent': 'com.google.android.youtube/20.10.38 (Linux; U; Android 12; US) gzip'
             },
             # https://github.com/yt-dlp/yt-dlp/pull/575#issuecomment-887739287
             #'thirdParty': {

--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -821,7 +821,8 @@ def get_captions(dummy):
         caption_data = get_caption_json_resp(video_id, lang, asr)
         if caption_data:
             caption_vtt = webvtt_from_caption_data(caption_data)
-            return caption_vtt.encode('utf-8')
+            return flask.Response(caption_vtt.encode('utf-8'),
+                                  mimetype = 'text/vtt')
         else:
             return b''
 


### PR DESCRIPTION
Add ability to obtain captions from `get_transcript` innertube api instead of using caption `baseUrl` of `player` response.

The feature is behind new settings: `use_innertube_for_captions`, which is set to `False` by default.

The protobuf encoded `params` for `get_transcript` is crafted using [blackboxprotobuf module](https://pypi.org/project/bbpb/) due to its lightweight size and easy-to-use.

Currently only manual and auto generated captions are supported. There is no support for translated captions, so request for translated captions will return the caption in its original language.

This will hopefully fix #239 