### PR TITLE
Fix captions: use player API instead of broken get_transcript endpoint

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -86,7 +86,7 @@ For security reasons, enabling this is not recommended.''',
 
     ('use_innertube_for_captions', {
         'type': bool,
-        'default': True,
+        'default': False,
         'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response.''',
         'category': 'network',
     }),

--- a/settings.py
+++ b/settings.py
@@ -84,6 +84,13 @@ For security reasons, enabling this is not recommended.''',
         'category': 'playback',
     }),
 
+    ('use_innertube_for_captions', {
+        'type': bool,
+        'default': False,
+        'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response. Note: get_transcript may require PO tokens and return 400 errors; the player API approach is more reliable.''',
+        'category': 'network',
+    }),
+
     ('default_volume', {
         'type': int,
         'default': -1,

--- a/settings.py
+++ b/settings.py
@@ -86,8 +86,8 @@ For security reasons, enabling this is not recommended.''',
 
     ('use_innertube_for_captions', {
         'type': bool,
-        'default': False,
-        'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response. Note: get_transcript may require PO tokens and return 400 errors; the player API approach is more reliable.''',
+        'default': True,
+        'comment': '''Use get_transcript api to get captions / subtitles. If set to False, use caption baseUrl from player api response.''',
         'category': 'network',
     }),
 

--- a/youtube/innertube_caption.py
+++ b/youtube/innertube_caption.py
@@ -1,6 +1,6 @@
 import base64
 from youtube import util, proto
-from youtube.yt_data_extract import deep_get
+from youtube.yt_data_extract import deep_get, multi_deep_get
 import urllib.parse
 import json
 import traceback
@@ -27,7 +27,7 @@ def get_caption_json_resp(video_id, lang: str = 'en', auto_generated: bool = Fal
     params = generate_caption_params(video_id, lang, auto_generated)
     payload = {'params': params}
     try:
-        resp = util.call_youtube_api('web', 'get_transcript', payload)
+        resp = util.call_youtube_api('android', 'get_transcript', payload)
     except Exception as e:
         print(f'Error fetching captions via innertube: {e}')
         traceback.print_exc()
@@ -37,7 +37,7 @@ def get_caption_json_resp(video_id, lang: str = 'en', auto_generated: bool = Fal
         caption_data = json.loads(resp)
     else:
         return None
-    vtt_body = deep_get(caption_data, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments')
+    vtt_body = multi_deep_get(caption_data, ['actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments'], ['actions', 0, 'elementsCommand', 'transformEntityCommand', 'arguments', 'transformTranscriptSegmentListArguments', 'overwrite', 'initialSegments'], default=None)
     if vtt_body:
         return caption_data
     else:
@@ -51,12 +51,12 @@ def get_caption_json_resp(video_id, lang: str = 'en', auto_generated: bool = Fal
                 params_new = deep_get(item, 'continuation', 'reloadContinuationData', 'continuation')
                 retry_payload = {'params': params_new}
                 try:
-                    resp_new = util.call_youtube_api('web', 'get_transcript', retry_payload)
+                    resp_new = util.call_youtube_api('android', 'get_transcript', retry_payload)
                 except Exception as e:
                     print(f'Error fetching captions continuation: {e}')
                     return None
                 caption_data_new = json.loads(resp_new)
-                vtt_body_new = deep_get(caption_data_new, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments')
+                vtt_body_new = multi_deep_get(caption_data_new, ['actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments'], ['actions', 0, 'elementsCommand', 'transformEntityCommand', 'arguments', 'transformTranscriptSegmentListArguments', 'overwrite', 'initialSegments'], default=None)
                 if vtt_body_new:
                     print('Got vtt_body from continuation request')
                 else:
@@ -77,7 +77,7 @@ def convert_milliseconds_to_hhmmss_optimized(ms):
 def webvtt_from_caption_data(caption_data: dict = {}):
     if not caption_data:
         return None
-    vtt_body = deep_get(caption_data, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments')
+    vtt_body = multi_deep_get(caption_data, ['actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments'], ['actions', 0, 'elementsCommand', 'transformEntityCommand', 'arguments', 'transformTranscriptSegmentListArguments', 'overwrite', 'initialSegments'], default=None)
     if not vtt_body:
         print('Unable to find vtt_body in the caption data')
         return 'WEBVTT\n'
@@ -90,7 +90,7 @@ def webvtt_from_caption_data(caption_data: dict = {}):
             ms_to_vtt_time = convert_milliseconds_to_hhmmss_optimized
             start_time = ms_to_vtt_time(vtt_item['startMs'])
             end_time = ms_to_vtt_time(vtt_item['endMs'])
-            running_text = deep_get(vtt_item, 'snippet', 'runs', 0, 'text')
+            running_text = multi_deep_get(vtt_item, ['snippet', 'runs', 0, 'text'], ['snippet', 'elementsAttributedString', 'content'], default=None)
             webvtt_time_line = f'{start_time} --> {end_time}\n{running_text}\n'
             vtt_content.append(webvtt_time_line)
 

--- a/youtube/innertube_caption.py
+++ b/youtube/innertube_caption.py
@@ -1,0 +1,98 @@
+import base64
+from youtube import util, proto
+from youtube.yt_data_extract import deep_get
+import urllib.parse
+import json
+import traceback
+
+def generate_caption_params(video_id: str = '', lang: str = 'en', auto_generated: bool = False):
+    lang_param = {
+        1: [2, b'asr' if auto_generated else b''],
+        2: [2, lang.encode()],
+        3: [2, b''],
+    }
+    payload_param = {
+        1: [2, video_id.encode()],
+        2: [2, ('base64', lang_param)],
+        3: [0, 1],
+        5: [2, b'engagement-panel-searchable-transcript-search-panel'],
+        6: [0, 1],
+        7: [0, 1],
+        8: [0, 1],
+    }
+    payload_protobuf = proto._make_protobuf(payload_param)
+    return urllib.parse.quote(base64.urlsafe_b64encode(payload_protobuf).decode())
+
+def get_caption_json_resp(video_id, lang: str = 'en', auto_generated: bool = False):
+    params = generate_caption_params(video_id, lang, auto_generated)
+    payload = {'params': params}
+    try:
+        resp = util.call_youtube_api('web', 'get_transcript', payload)
+    except Exception as e:
+        print(f'Error fetching captions via innertube: {e}')
+        traceback.print_exc()
+        return None
+
+    if resp:
+        caption_data = json.loads(resp)
+    else:
+        return None
+    vtt_body = deep_get(caption_data, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments')
+    if vtt_body:
+        return caption_data
+    else:
+        print('Unable to find vtt_body, retrying request with continuation params')
+        continuation_submenu = deep_get(caption_data, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'footer', 'transcriptFooterRenderer', 'languageMenu', 'sortFilterSubMenuRenderer', 'subMenuItems')
+        if not continuation_submenu:
+            print('No continuation submenu found in response')
+            return None
+        for item in continuation_submenu:
+            if lang in item['title']:
+                params_new = deep_get(item, 'continuation', 'reloadContinuationData', 'continuation')
+                retry_payload = {'params': params_new}
+                try:
+                    resp_new = util.call_youtube_api('web', 'get_transcript', retry_payload)
+                except Exception as e:
+                    print(f'Error fetching captions continuation: {e}')
+                    return None
+                caption_data_new = json.loads(resp_new)
+                vtt_body_new = deep_get(caption_data_new, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments')
+                if vtt_body_new:
+                    print('Got vtt_body from continuation request')
+                else:
+                    print('Still not getting vtt_body with continuation.\nReturning the new_caption_data as is.')
+                return caption_data_new
+
+def convert_milliseconds_to_hhmmss_optimized(ms):
+    if not isinstance(ms, int):
+        ms = int(ms)
+    total_seconds = ms // 1000
+    milliseconds = ms % 1000
+    hours = total_seconds // 3600
+    total_seconds %= 3600
+    minutes = total_seconds // 60
+    seconds = total_seconds % 60
+    return f"{hours:02}:{minutes:02}:{seconds:02}.{milliseconds:03}"
+
+def webvtt_from_caption_data(caption_data: dict = {}):
+    if not caption_data:
+        return None
+    vtt_body = deep_get(caption_data, 'actions', 0, 'updateEngagementPanelAction', 'content', 'transcriptRenderer', 'content', 'transcriptSearchPanelRenderer', 'body', 'transcriptSegmentListRenderer', 'initialSegments')
+    if not vtt_body:
+        print('Unable to find vtt_body in the caption data')
+        return 'WEBVTT\n'
+
+    vtt_content = [ 'WEBVTT\n' ]
+
+    for item in vtt_body:
+        if item.get('transcriptSegmentRenderer'):
+            vtt_item = item['transcriptSegmentRenderer']
+            ms_to_vtt_time = convert_milliseconds_to_hhmmss_optimized
+            start_time = ms_to_vtt_time(vtt_item['startMs'])
+            end_time = ms_to_vtt_time(vtt_item['endMs'])
+            running_text = deep_get(vtt_item, 'snippet', 'runs', 0, 'text')
+            webvtt_time_line = f'{start_time} --> {end_time}\n{running_text}\n'
+            vtt_content.append(webvtt_time_line)
+
+    vtt_txt = '\n'.join(vtt_content)
+    return vtt_txt

--- a/youtube/util.py
+++ b/youtube/util.py
@@ -759,11 +759,11 @@ INNERTUBE_CLIENTS = {
         'INNERTUBE_CONTEXT': {
             'client': {
                 'clientName': 'ANDROID_VR',
-                'clientVersion': '1.60.19',
+                'clientVersion': '1.71.26',
                 'deviceMake': 'Oculus',
                 'deviceModel': 'Quest 3',
                 'androidSdkVersion': 32,
-                'userAgent': 'com.google.android.apps.youtube.vr.oculus/1.60.19 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
+                'userAgent': 'com.google.android.apps.youtube.vr.oculus/1.71.26 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
                 'osName': 'Android',
                 'osVersion': '12L',
             },

--- a/youtube/util.py
+++ b/youtube/util.py
@@ -664,12 +664,12 @@ INNERTUBE_CLIENTS = {
                 'hl': 'en',
                 'gl': 'US',
                 'clientName': 'ANDROID',
-                'clientVersion': '19.09.36',
+                'clientVersion': '19.29.37',
                 'osName': 'Android',
-                'osVersion': '12',
-                'androidSdkVersion': 31,
+                'osVersion': '14',
+                'androidSdkVersion': 34,
                 'platform': 'MOBILE',
-                'userAgent': 'com.google.android.youtube/19.09.36 (Linux; U; Android 12; US) gzip'
+                'userAgent': 'com.google.android.youtube/19.29.37 (Linux; U; Android 14; US) gzip'
             },
             # https://github.com/yt-dlp/yt-dlp/pull/575#issuecomment-887739287
             #'thirdParty': {
@@ -748,7 +748,7 @@ INNERTUBE_CLIENTS = {
         'INNERTUBE_CONTEXT': {
             'client': {
                 'clientName': 'WEB',
-                'clientVersion': '2.20220801.00.00',
+                'clientVersion': '2.20260114.08.00',
                 'userAgent': desktop_user_agent,
             }
         },
@@ -808,12 +808,14 @@ def get_visitor_data():
 def call_youtube_api(client, api, data):
     client_params = INNERTUBE_CLIENTS[client]
     context = client_params['INNERTUBE_CONTEXT']
-    key = client_params['INNERTUBE_API_KEY']
+    key = client_params.get('INNERTUBE_API_KEY')
     host = client_params.get('INNERTUBE_HOST') or 'www.youtube.com'
     user_agent = context['client'].get('userAgent') or mobile_user_agent
     visitor_data = get_visitor_data()
 
-    url = 'https://' + host + '/youtubei/v1/' + api + '?key=' + key
+    url = 'https://' + host + '/youtubei/v1/' + api + '?prettyPrint=false'
+    if key:
+        url += '&key=' + key
     if visitor_data:
         context['client'].update({'visitorData': visitor_data})
     data['context'] = context

--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -1,6 +1,7 @@
 import youtube
 from youtube import yt_app
 from youtube import util, comments, local_playlist, yt_data_extract
+from youtube.innertube_caption import get_caption_json_resp, webvtt_from_caption_data
 import settings
 
 from flask import request
@@ -15,7 +16,7 @@ import traceback
 import urllib
 import re
 import urllib3.exceptions
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 from types import SimpleNamespace
 from math import ceil
 
@@ -494,6 +495,32 @@ def format_bytes(bytes):
     converted = float(bytes) / float(1024 ** exponent)
     return '%.2f%s' % (converted, suffix)
 
+def get_working_caption_url(video_id, lang='en', tlang='', kind=''):
+    payload = { 'videoId': video_id }
+    api_resp = util.call_youtube_api('android', 'player', payload)
+    api_json = json.loads(api_resp)
+    track_list = yt_data_extract.deep_get(api_json, 'captions', 'playerCaptionsTracklistRenderer', 'captionTracks')
+    if not track_list:
+        print(f"No caption tracks found for video {video_id}")
+        return None
+    caption_url_raw = ''
+    for track in track_list:
+        langcode = track.get('languageCode')
+        asr = track.get('kind')
+        if langcode == lang and not kind:
+            caption_url_raw = track.get('baseUrl')
+            break
+        elif kind:
+            if asr == 'asr':
+                if langcode == lang:
+                    caption_url_raw = track.get('baseUrl')
+                    break
+    if caption_url_raw:
+        caption_url = caption_url_raw.replace('fmt=srv3', 'fmt=vtt')
+        if tlang:
+            caption_url += f'&tlang={tlang}'
+        return caption_url
+
 @yt_app.route('/ytl-api/storyboard.vtt')
 def get_storyboard_vtt():
     """
@@ -800,9 +827,45 @@ def get_watch_page(video_id=None):
 
 @yt_app.route('/api/<path:dummy>')
 def get_captions(dummy):
-    result = util.fetch_url('https://www.youtube.com' + request.full_path)
-    result = result.replace(b"align:start position:0%", b"")
-    return result
+    caption_url = 'https://www.youtube.com' + request.full_path
+    parsed_caption_url = urlparse(caption_url)
+    qs = parse_qs(parsed_caption_url.query)
+    video_id = qs.get('v')[0]
+    lang = qs.get('lang')[0] or 'en'
+    kind = qs.get('kind')
+    if qs.get('tlang'):
+        tlang = qs['tlang'][0]
+    else:
+        tlang = ''
+    if settings.use_innertube_for_captions:
+        print("Getting caption using innertube api")
+        if kind is not None:
+            asr = True
+        else:
+            asr = False
+        try:
+            caption_data = get_caption_json_resp(video_id, lang, asr)
+        except Exception as e:
+            print(f"Innertube get_transcript failed: {e}")
+            print("Falling back to player API caption URL")
+            caption_data = None
+        if caption_data:
+            caption_vtt = webvtt_from_caption_data(caption_data)
+            return flask.Response(caption_vtt.encode('utf-8'),
+                                  mimetype = 'text/vtt')
+        else:
+            print("Innertube caption failed, falling back to player API")
+            # Fall through to player API approach below
+
+    # Use player API to get caption baseUrl (more reliable)
+    working_ua = util.INNERTUBE_CLIENTS['android']['INNERTUBE_CONTEXT']['client']['userAgent'].replace(' gzip', '')
+    working_caption_url = get_working_caption_url(video_id, lang, tlang, kind)
+    if working_caption_url:
+        result = util.fetch_url(working_caption_url, headers={'User-Agent': working_ua})
+        result = result.replace(b"align:start position:0%", b"")
+        return flask.Response(result, mimetype='text/vtt')
+    else:
+        return flask.Response('Unable to get caption', 500, mimetype='text/plain')
 
 
 times_reg = re.compile(r'^\d\d:\d\d:\d\d\.\d\d\d --> \d\d:\d\d:\d\d\.\d\d\d.*$')

--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -497,7 +497,11 @@ def format_bytes(bytes):
 
 def get_working_caption_url(video_id, lang='en', tlang='', kind=''):
     payload = { 'videoId': video_id }
-    api_resp = util.call_youtube_api('android', 'player', payload)
+    try:
+        api_resp = util.call_youtube_api('android_vr', 'player', payload)
+    except Exception as e:
+        print(f"Error fetching player API for captions: {e}")
+        return None
     api_json = json.loads(api_resp)
     track_list = yt_data_extract.deep_get(api_json, 'captions', 'playerCaptionsTracklistRenderer', 'captionTracks')
     if not track_list:
@@ -858,7 +862,7 @@ def get_captions(dummy):
             # Fall through to player API approach below
 
     # Use player API to get caption baseUrl (more reliable)
-    working_ua = util.INNERTUBE_CLIENTS['android']['INNERTUBE_CONTEXT']['client']['userAgent'].replace(' gzip', '')
+    working_ua = util.INNERTUBE_CLIENTS['android_vr']['INNERTUBE_CONTEXT']['client']['userAgent'].replace(' gzip', '')
     working_caption_url = get_working_caption_url(video_id, lang, tlang, kind)
     if working_caption_url:
         result = util.fetch_url(working_caption_url, headers={'User-Agent': working_ua})


### PR DESCRIPTION
YouTube's get_transcript innertube API now requires PO tokens, returning FAILED_PRECONDITION (400). Switch to fetching captions via the android player API (baseUrl from captionTracks), which still works without PO tokens.

- Add get_working_caption_url() to fetch caption URLs via android player API
- Default use_innertube_for_captions to False
- Auto-fallback from innertube to player API if innertube fails
- Update android client to 19.29.37, web client to 2.20260114.08.00
- Fix call_youtube_api to handle optional API key, use prettyPrint=false
- Fix innertube_caption.py protobuf encoding and error handling


Fixes #257