### PR TITLE
Stop proxying watch-page MP4/WebM format URLs through youtube-local

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,4 +1,8 @@
-from youtube import watch
+import urllib.parse
+
+from youtube import util, watch
+
+TEST_TITLE_WITH_INVALID_CHARS = 'a:b?/\\*<>|"'
 
 
 def test_add_video_title_to_format_urls_keeps_direct_urls():
@@ -13,9 +17,32 @@ def test_add_video_title_to_format_urls_keeps_direct_urls():
         },
     ]
 
-    watch.add_video_title_to_format_urls(formats, 'a:b?')
+    title = TEST_TITLE_WITH_INVALID_CHARS
+    expected_name = urllib.parse.quote(util.to_valid_filename(title))
+    watch.add_video_title_to_format_urls(formats, title)
 
     assert formats[0]['url'].startswith('https://')
     assert not formats[0]['url'].startswith('/https://')
-    assert '/videoplayback/name/a-b.mp4?' in formats[0]['url']
-    assert '/videoplayback/name/a-b?' in formats[1]['url']
+    assert '/videoplayback/name/' + expected_name + '.mp4?' in formats[0]['url']
+    assert '/videoplayback/name/' + expected_name + '?' in formats[1]['url']
+
+
+def test_add_video_title_to_format_urls_handles_missing_title():
+    formats = [
+        {
+            'url': 'https://rr2---sn-8xgp1vo-3uhs.googlevideo.com/videoplayback?foo=bar',
+            'ext': 'mp4',
+        },
+    ]
+
+    watch.add_video_title_to_format_urls(formats, None)
+    assert '/videoplayback/name/_.mp4?' in formats[0]['url']
+
+    formats = [
+        {
+            'url': 'https://rr2---sn-8xgp1vo-3uhs.googlevideo.com/videoplayback?foo=bar',
+            'ext': 'mp4',
+        },
+    ]
+    watch.add_video_title_to_format_urls(formats, '')
+    assert '/videoplayback/name/_.mp4?' in formats[0]['url']

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -2,7 +2,7 @@ import urllib.parse
 
 from youtube import util, watch
 
-TEST_TITLE_WITH_INVALID_CHARS = 'a:b?/\\*<>|"'
+TEST_TITLE_WITH_INVALID_FILENAME_CHARS = 'a:b?/\\*<>|"'
 
 
 def test_add_video_title_to_format_urls_keeps_direct_urls():
@@ -17,8 +17,9 @@ def test_add_video_title_to_format_urls_keeps_direct_urls():
         },
     ]
 
-    title = TEST_TITLE_WITH_INVALID_CHARS
+    title = TEST_TITLE_WITH_INVALID_FILENAME_CHARS
     expected_name = urllib.parse.quote(util.to_valid_filename(title))
+    assert expected_name == 'a-b_____-%27'
     watch.add_video_title_to_format_urls(formats, title)
 
     assert formats[0]['url'].startswith('https://')

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,21 @@
+from youtube import watch
+
+
+def test_add_video_title_to_format_urls_keeps_direct_urls():
+    formats = [
+        {
+            'url': 'https://rr2---sn-8xgp1vo-3uhs.googlevideo.com/videoplayback?foo=bar',
+            'ext': 'mp4',
+        },
+        {
+            'url': 'https://rr2---sn-8xgp1vo-3uhs.googlevideo.com/videoplayback?baz=qux',
+            'ext': None,
+        },
+    ]
+
+    watch.add_video_title_to_format_urls(formats, 'a:b?')
+
+    assert formats[0]['url'].startswith('https://')
+    assert not formats[0]['url'].startswith('/https://')
+    assert '/videoplayback/name/a-b.mp4?' in formats[0]['url']
+    assert '/videoplayback/name/a-b?' in formats[1]['url']

--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -553,6 +553,19 @@ def get_storyboard_vtt():
     return flask.Response(r, mimetype='text/vtt')
 
 
+def add_video_title_to_format_urls(formats, title):
+    '''Add video title to end of format URL path for download-friendly names.'''
+    title = urllib.parse.quote(util.to_valid_filename(title or ''))
+    for fmt in formats:
+        filename = title
+        ext = fmt.get('ext')
+        if ext:
+            filename += '.' + ext
+        fmt['url'] = fmt['url'].replace(
+            '/videoplayback',
+            '/videoplayback/name/' + filename)
+
+
 time_table = {'h': 3600, 'm': 60, 's': 1}
 @yt_app.route('/watch')
 @yt_app.route('/embed')
@@ -623,23 +636,9 @@ def get_watch_page(video_id=None):
                 item['url'] += '&index=' + str(item['index'])
         info['playlist']['author_url'] = util.prefix_url(
             info['playlist']['author_url'])
-    if settings.img_prefix:
-        # Don't prefix hls_formats for now because the urls inside the manifest
-        # would need to be prefixed as well.
-        for fmt in info['formats']:
-            fmt['url'] = util.prefix_url(fmt['url'])
-
-    # Add video title to end of url path so it has a filename other than just
-    # "videoplayback" when downloaded
-    title = urllib.parse.quote(util.to_valid_filename(info['title'] or ''))
-    for fmt in info['formats']:
-        filename = title
-        ext = fmt.get('ext')
-        if ext:
-            filename += '.' + ext
-        fmt['url'] = fmt['url'].replace(
-            '/videoplayback',
-            '/videoplayback/name/' + filename)
+    # Keep format URLs direct (not routed through youtube-local), and add
+    # title-based download filenames.
+    add_video_title_to_format_urls(info['formats'], info['title'])
 
 
     download_formats = []
@@ -866,6 +865,5 @@ def get_transcript(caption_path):
 
     return flask.Response(result.encode('utf-8'),
         mimetype='text/plain;charset=UTF-8')
-
 
 

--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -554,7 +554,18 @@ def get_storyboard_vtt():
 
 
 def add_video_title_to_format_urls(formats, title):
-    '''Add video title to end of format URL path for download-friendly names.'''
+    '''Add a sanitized title segment to each format URL in-place.
+
+    URLs with /videoplayback are rewritten to
+    /videoplayback/name/<title>[.<ext>]...
+    Empty titles become "_" via util.to_valid_filename.
+
+    Args:
+        formats: List of format dictionaries containing a 'url' key and
+            optional 'ext' key. Each dictionary is modified in-place.
+        title: Video title string (or None) used to build the filename
+            segment inserted into each format URL.
+    '''
     title = urllib.parse.quote(util.to_valid_filename(title or ''))
     for fmt in formats:
         filename = title
@@ -563,7 +574,8 @@ def add_video_title_to_format_urls(formats, title):
             filename += '.' + ext
         fmt['url'] = fmt['url'].replace(
             '/videoplayback',
-            '/videoplayback/name/' + filename)
+            '/videoplayback/name/' + filename,
+            1)
 
 
 time_table = {'h': 3600, 'm': 60, 's': 1}
@@ -865,5 +877,3 @@ def get_transcript(caption_path):
 
     return flask.Response(result.encode('utf-8'),
         mimetype='text/plain;charset=UTF-8')
-
-

--- a/youtube/watch.py
+++ b/youtube/watch.py
@@ -558,6 +558,7 @@ def add_video_title_to_format_urls(formats, title):
 
     URLs with /videoplayback are rewritten to
     /videoplayback/name/<title>[.<ext>]...
+    URLs without /videoplayback are left unchanged.
     Empty titles become "_" via util.to_valid_filename.
 
     Args:
@@ -572,10 +573,11 @@ def add_video_title_to_format_urls(formats, title):
         ext = fmt.get('ext')
         if ext:
             filename += '.' + ext
-        fmt['url'] = fmt['url'].replace(
-            '/videoplayback',
-            '/videoplayback/name/' + filename,
-            1)
+        if '/videoplayback' in fmt['url']:
+            fmt['url'] = fmt['url'].replace(
+                '/videoplayback',
+                '/videoplayback/name/' + filename,
+                1)
 
 
 time_table = {'h': 3600, 'm': 60, 's': 1}


### PR DESCRIPTION
Watch-page downloadable/playable format URLs (MP4/WebM/etc.) were being rewritten through youtube-local routing (`/https://...`) instead of being accessed directly. This PR keeps those format URLs direct while preserving existing filename-friendly download URL shaping.

- **Direct format URL behavior**
  - Removed local prefixing of `info['formats']` URLs in `get_watch_page`.
  - Result: format URLs remain direct upstream URLs (e.g. `https://...googlevideo.com/...`) instead of being routed through youtube-local.

- **Refactored URL rewrite logic (no behavior loss)**
  - Introduced `add_video_title_to_format_urls(formats, title)` in `youtube/watch.py`.
  - Preserves current `/videoplayback/name/<sanitized-title>[.<ext>]` rewrite so downloads still get meaningful filenames.
  - Leaves URLs unchanged if `/videoplayback` is not present.

- **Focused regression coverage**
  - Added `tests/test_watch.py` to validate:
    - format URLs stay direct (not `/https://...`)
    - title/extension rewrite still applies
    - sanitization handling for invalid filename chars
    - empty/missing title edge case (`_` fallback)

```python
# before: optional local prefixing could produce /https://... URLs
# now: keep direct URL and only apply filename path rewrite
if '/videoplayback' in fmt['url']:
    fmt['url'] = fmt['url'].replace(
        '/videoplayback',
        '/videoplayback/name/' + filename,
        1
    )
```

- **screenshot**
  - https://github.com/user-attachments/assets/8741ca1b-2c49-4afe-a99e-c1a3e21771b9